### PR TITLE
middleware-server: Log user agent

### DIFF
--- a/logaccess.go
+++ b/logaccess.go
@@ -127,3 +127,11 @@ func DefaultAccessReporter(logger *log.Logger) AccessReporter {
 		logger.Info("%s %s %d %d %d", entry.requestMethod, entry.requestURI, entry.statusCode, entry.size, milliseconds)
 	}
 }
+
+// ExtendedAccessReporter createsan access logger that logs everything that DefaultAccessReporter does with the User-Agent added to that
+func ExtendedAccessReporter(logger *log.Logger) AccessReporter {
+	return func(entry *AccessEntry) {
+		milliseconds := int(entry.duration / time.Millisecond)
+		logger.Info("%s %s %d %d %d %s", entry.requestMethod, entry.requestURI, entry.statusCode, entry.size, milliseconds, entry.Request().Header.Get("User-Agent"))
+	}
+}

--- a/server.go
+++ b/server.go
@@ -47,10 +47,11 @@ type Context struct {
 
 type Server struct {
 	// The address to listen on.
-	addr         string
-	accessLogger *log.Logger
-	statusLogger *log.Logger
-	listener     net.Listener
+	addr                string
+	accessLogger        *log.Logger
+	statusLogger        *log.Logger
+	listener            net.Listener
+	extendAccessLogging bool
 
 	preHTTPHandler  AccessReporter
 	postHTTPHandler AccessReporter
@@ -108,6 +109,11 @@ func (this *Server) ServeNotFound(middlewares ...Middleware) {
 	this.Router.NotFoundHandler = this.NewMiddlewareHandler(middlewares)
 }
 
+// ExtendAccessLogging turns on the usage of ExtendedAccessLogger
+func (s *Server) ExtendAccessLogging() {
+	s.extendAccessLogging = true
+}
+
 func (s *Server) RegisterRoutes(mux *http.ServeMux, prefix string) {
 	if s.alreadyRegisteredRoutes {
 		return
@@ -116,8 +122,12 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux, prefix string) {
 	var handler http.Handler = s.Router
 
 	if s.accessLogger != nil {
+		reporter := DefaultAccessReporter(s.accessLogger)
+		if s.extendAccessLogging {
+			reporter = ExtendedAccessReporter(s.accessLogger)
+		}
 		handler = NewLogAccessHandler(
-			DefaultAccessReporter(s.accessLogger),
+			reporter,
 			s.preHTTPHandler,
 			s.postHTTPHandler,
 			handler,


### PR DESCRIPTION
Added ExtendedAccessLogger and logic to use it.

Using it will add the user-agent to the end of the per-request log line.