### PR TITLE
ResponseWriter.WriteHeader once for async middlewares

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,9 @@
+package server
+
+import (
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)

--- a/func_name.go
+++ b/func_name.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var funcNameRegExp = regexp.MustCompile("([a-zA-Z0-9_]+)(.*)")
+
+func funcName(i interface{}) string {
+	raw := runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	splitted := strings.Split(raw, ".")
+	last := splitted[len(splitted)-1]
+	return funcNameRegExp.ReplaceAllString(last, "$1")
+}

--- a/responder.go
+++ b/responder.go
@@ -2,51 +2,80 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"sync"
 )
 
 type Response struct {
-	w http.ResponseWriter
+	once sync.Once
+	w    http.ResponseWriter
 }
 
 func (response *Response) Json(result interface{}, code int) error {
-	response.w.Header().Add("Content-Type", "application/json")
-	response.w.WriteHeader(code)
-	return json.NewEncoder(response.w).Encode(result)
+	response.once.Do(func() {
+		response.w.Header().Add("Content-Type", "application/json")
+		response.w.WriteHeader(code)
+		if err := json.NewEncoder(response.w).Encode(result); err != nil {
+			fmt.Printf("json.NewEncoder: %#v\n", err)
+		}
+	})
+
+	return nil
 }
 
-func (response *Response) Error(message string, code int) error {
-	return response.PlainText(message, code)
+func (response *Response) Error(content string, code int) error {
+	response.once.Do(func() {
+		response.w.WriteHeader(code)
+		response.w.Write([]byte(content))
+	})
+
+	return fmt.Errorf(content)
 }
 
 func (response *Response) PlainText(content string, code int) error {
-	response.w.WriteHeader(code)
-	response.w.Write([]byte(content))
+	response.once.Do(func() {
+		response.w.WriteHeader(code)
+		response.w.Write([]byte(content))
+	})
+
 	return nil
 }
 
 func (response *Response) NoContent() error {
-	response.w.WriteHeader(http.StatusNoContent)
+	response.once.Do(func() {
+		response.w.WriteHeader(http.StatusNoContent)
+	})
+
 	return nil
 }
 
 // Unauthorized sends the http.StatusUnauthorized status code.
 // Use this to signal the requestee that the authentication failed.
 func (response *Response) Unauthorized(scheme string) error {
-	response.w.Header().Add("WWW-Authenticate", scheme)
-	response.w.WriteHeader(http.StatusUnauthorized)
-	return nil
+	response.once.Do(func() {
+		response.w.Header().Add("WWW-Authenticate", scheme)
+		response.w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	return fmt.Errorf("401 Unauthorized")
 }
 
 // Forbidden sends the http.StatusForbidden status.
 // Use it to signal that the requestee has no access to the given resource (but auth itself worked).
 func (response *Response) Forbidden() error {
-	response.w.WriteHeader(http.StatusForbidden)
-	return nil
+	response.once.Do(func() {
+		response.w.WriteHeader(http.StatusForbidden)
+	})
+
+	return fmt.Errorf("403 Forbidden")
 }
 
 func (response *Response) Redirect(location string, code int) error {
-	response.w.Header().Set("Location", location)
-	response.w.WriteHeader(code)
+	response.once.Do(func() {
+		response.w.Header().Set("Location", location)
+		response.w.WriteHeader(code)
+	})
+
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -36,7 +37,7 @@ type Context struct {
 	MuxVars map[string]string
 
 	// Helper to quickly write results to the `http.ResponseWriter`.
-	Response Response
+	Response *Response
 
 	// A middleware should call Next() to signal that no problem was encountered
 	// and the next middleware in the chain can be executed after this middleware
@@ -255,8 +256,9 @@ func (s *Server) NewMiddlewareHandler(middlewares []Middleware) http.Handler {
 			ctx := &Context{
 				MuxVars: mux.Vars(req),
 				Request: requestCtx,
-				Response: Response{
-					w: res,
+				Response: &Response{
+					w:    res,
+					once: sync.Once{},
 				},
 			}
 

--- a/server.go
+++ b/server.go
@@ -275,8 +275,6 @@ func (s *Server) NewMiddlewareHandler(middlewares []Middleware) http.Handler {
 
 				// End the request with an error and stop calling further middlewares.
 				if err := middleware(res, req, ctx); err != nil {
-					s.Logger.Error(requestCtx, "%s %s %#v", req.Method, req.URL, errgo.Mask(err))
-
 					ctx.Response.Error(err.Error(), http.StatusInternalServerError)
 					break
 				}


### PR DESCRIPTION
This ensures `ResponseWriter.WriteHeader` is just called once. To accomplish that we just use `sync.Once`.